### PR TITLE
Fix unload_model typo

### DIFF
--- a/wd_llm_caption/utils/inference.py
+++ b/wd_llm_caption/utils/inference.py
@@ -934,7 +934,7 @@ class LLM:
             self.logger.info(f'Unloading LLM...')
             start = time.monotonic()
             del self.llm
-            if hasattr(self, "llm_processer"):
+            if hasattr(self, "llm_processor"):
                 del self.llm_processor
             if hasattr(self, "llm_tokenizer"):
                 del self.llm_tokenizer


### PR DESCRIPTION
## Summary
- fix a typo so LLM processor gets cleaned up during `unload_model`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check . | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6844642142908324b1a0f7225b1180d1