### PR TITLE
Add top‑k and top‑p sliders to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,14 @@ temperature for LLM model, default is `0`，means use llm own default value.
 
 max tokens for LLM model output, default is `0`, means use llm own default value.
 
+`--llm_top_k`
+
+top-k sampling for LLM model, default use model's value.
+
+`--llm_top_p`
+
+top-p sampling for LLM model, default use model's value.
+
 </details>
 
 ## Credits

--- a/wd_llm_caption/caption.py
+++ b/wd_llm_caption/caption.py
@@ -9,9 +9,16 @@ from tqdm import tqdm
 
 from .utils.download import download_models
 from .utils.image import get_image_paths
-from .utils.inference import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT_WITHOUT_WD, DEFAULT_USER_PROMPT_WITH_WD
-from .utils.inference import get_caption_file_path, LLM, Tagger
+from .utils.inference import (
+    DEFAULT_SYSTEM_PROMPT,
+    DEFAULT_USER_PROMPT_WITH_WD,
+    DEFAULT_USER_PROMPT_WITHOUT_WD,
+    LLM,
+    Tagger,
+    get_caption_file_path,
+)
 from .utils.logger import Logger, print_title
+
 
 DEFAULT_MODELS_SAVE_PATH = str(os.path.join(os.getcwd(), "models"))
 
@@ -40,7 +47,7 @@ class Caption:
             args: argparse.Namespace
     ):
         if not args.data_path:
-            print(f"`data_path` not defined, use `--data_path` add your datasets path!!!")
+            print("`data_path` not defined, use `--data_path` add your datasets path!!!")
             raise ValueError
         if not os.path.exists(args.data_path):
             print(f"`{args.data_path}` not exists!!!")
@@ -261,11 +268,11 @@ class Caption:
             # Set joy user prompt
             if args.llm_user_prompt == DEFAULT_USER_PROMPT_WITHOUT_WD:
                 if not args.llm_caption_without_wd:
-                    self.my_logger.warning(f"LLM user prompt not defined, using default version with wd tags...")
+                    self.my_logger.warning("LLM user prompt not defined, using default version with wd tags...")
                     args.llm_user_prompt = DEFAULT_USER_PROMPT_WITH_WD
             # run
             if args.run_method == "sync":
-                self.my_logger.info(f"Running in sync mode...")
+                self.my_logger.info("Running in sync mode...")
                 image_paths = get_image_paths(logger=self.my_logger, path=Path(args.data_path),
                                               recursive=args.recursive)
                 pbar = tqdm(total=len(image_paths), smoothing=0.0)
@@ -328,7 +335,9 @@ class Caption:
                                 system_prompt=str(args.llm_system_prompt),
                                 user_prompt=str(args.llm_user_prompt).format(wd_tags=tag_text),
                                 temperature=args.llm_temperature,
-                                max_new_tokens=args.llm_max_tokens
+                                max_new_tokens=args.llm_max_tokens,
+                                top_k=args.llm_top_k,
+                                top_p=args.llm_top_p,
                             )
                             if not (args.not_overwrite and os.path.isfile(llm_caption_file)):
                                 # Write LLM Caption
@@ -393,7 +402,7 @@ class Caption:
                     for tag, freq in sorted_tags:
                         self.my_logger.info(f'{tag}: {freq}')
             else:
-                self.my_logger.info(f"Running in queue mode...")
+                self.my_logger.info("Running in queue mode...")
                 pbar = tqdm(total=2, smoothing=0.0)
                 pbar.set_description('Processing with WD model...')
                 self.my_tagger.inference()
@@ -751,6 +760,16 @@ def setup_args() -> argparse.Namespace:
         type=int,
         default=0,
         help='max tokens for LLM model output, default is `0`, means use llm own default value.'
+    )
+    llm_args.add_argument(
+        '--llm_top_k',
+        type=int,
+        help='top-k sampling for LLM model, default use model setting.'
+    )
+    llm_args.add_argument(
+        '--llm_top_p',
+        type=float,
+        help='top-p sampling for LLM model, default use model setting.'
     )
 
     gradio_args = args.add_argument_group("Gradio dummy args, no effects")

--- a/wd_llm_caption/gui.py
+++ b/wd_llm_caption/gui.py
@@ -10,6 +10,7 @@ from . import caption
 from .utils import inference
 from .utils.logger import print_title
 
+
 WD_CONFIG = os.path.join(os.path.dirname(__file__), "configs", "default_wd.json")
 JOY_CONFIG = os.path.join(os.path.dirname(__file__), "configs", "default_joy.json")
 LLAMA_CONFIG = os.path.join(os.path.dirname(__file__), "configs", "default_llama_3.2V.json")
@@ -75,7 +76,7 @@ def gui():
                 #                             choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                 #                             value="INFO")
 
-                with gr.Row(equal_height=True) as models_settings:
+                with gr.Row(equal_height=True):
                     with gr.Column(min_width=240):
                         with gr.Column(min_width=240):
                             caption_method = gr.Radio(label="Caption method", choices=["WD+LLM", "WD", "LLM"],
@@ -210,6 +211,10 @@ def gui():
                                                         minimum=0, maximum=1.0, value=0, step=0.1)
                             llm_max_tokens = gr.Slider(label="max token for LLM model",
                                                        minimum=0, maximum=2048, value=0, step=1)
+                            llm_top_k = gr.Slider(label="top-k for LLM model",
+                                                 minimum=0, maximum=200, value=0, step=1)
+                            llm_top_p = gr.Slider(label="top-p for LLM model",
+                                                 minimum=0, maximum=1.0, value=0, step=0.05)
                             image_size = gr.Slider(label="Resize image for inference",
                                                    minimum=256, maximum=2048, value=1024, step=1)
                             auto_unload = gr.Checkbox(label="Auto Unload Models after inference.")
@@ -231,7 +236,7 @@ def gui():
                         llm_caption_output = gr.Text(label='LLM Caption Output', lines=10,
                                                      interactive=False, show_label=True, show_copy_button=True)
 
-                with gr.Tab("Batch mode") as bs_mode:
+                with gr.Tab("Batch mode"):
                     with gr.Column(min_width=240):
                         with gr.Row():
                             input_dir = gr.Textbox(label="Batch Directory",
@@ -510,6 +515,8 @@ def gui():
                                        llm_user_prompt,
                                        llm_temperature,
                                        llm_max_tokens,
+                                       llm_top_k,
+                                       llm_top_p,
                                        image_size,
                                        auto_unload,
                                        input_image]
@@ -536,6 +543,8 @@ def gui():
                                       llm_user_prompt,
                                       llm_temperature,
                                       llm_max_tokens,
+                                      llm_top_k,
+                                      llm_top_p,
                                       image_size,
                                       auto_unload,
                                       input_dir,
@@ -653,6 +662,8 @@ def gui():
                                      llm_user_prompt_value,
                                      llm_temperature_value,
                                      llm_max_tokens_value,
+                                     llm_top_k_value,
+                                     llm_top_p_value,
                                      image_size_value,
                                      auto_unload_value,
                                      input_image_value):
@@ -681,6 +692,8 @@ def gui():
             args.llm_user_prompt = str(llm_user_prompt_value)
             args.llm_temperature = float(llm_temperature_value)
             args.llm_max_tokens = int(llm_max_tokens_value)
+            args.llm_top_k = int(llm_top_k_value) if int(llm_top_k_value) != 0 else None
+            args.llm_top_p = float(llm_top_p_value) if float(llm_top_p_value) != 0 else None
 
             args.image_size = int(image_size_value)
 
@@ -715,7 +728,9 @@ def gui():
                     user_prompt=str(args.llm_user_prompt).format(wd_tags=tag_text) if tag_text else \
                         str(args.llm_user_prompt),
                     temperature=args.llm_temperature,
-                    max_new_tokens=args.llm_max_tokens
+                    max_new_tokens=args.llm_max_tokens,
+                    top_k=args.llm_top_k,
+                    top_p=args.llm_top_p,
                 )
                 get_caption_fn.my_logger.info(f"LLM Caption content: {caption_text}")
             gr.Info(f"Inference end in {time.monotonic() - start_time:.1f}s.")
@@ -746,6 +761,8 @@ def gui():
                                     llm_user_prompt_value,
                                     llm_temperature_value,
                                     llm_max_tokens_value,
+                                    llm_top_k_value,
+                                    llm_top_p_value,
                                     image_size_value,
                                     auto_unload_value,
                                     input_dir_value,
@@ -787,6 +804,8 @@ def gui():
                 args.llm_user_prompt = str(llm_user_prompt_value)
                 args.llm_temperature = float(llm_temperature_value)
                 args.llm_max_tokens = int(llm_max_tokens_value)
+                args.llm_top_k = int(llm_top_k_value) if int(llm_top_k_value) != 0 else None
+                args.llm_top_p = float(llm_top_p_value) if float(llm_top_p_value) != 0 else None
 
                 args.image_size = int(image_size_value)
 
@@ -818,7 +837,7 @@ def gui():
         def caption_unload_models():
             global IS_MODEL_LOAD
             if IS_MODEL_LOAD:
-                get_caption_args, get_caption_fn = ARGS, CAPTION_FN
+                _, get_caption_fn = ARGS, CAPTION_FN
                 get_caption_fn.unload_models()
 
                 IS_MODEL_LOAD = False

--- a/wd_llm_caption/utils/image.py
+++ b/wd_llm_caption/utils/image.py
@@ -11,6 +11,7 @@ from PIL import Image
 
 from .logger import Logger
 
+
 SUPPORT_IMAGE_FORMATS = ("bmp", "jpg", "jpeg", "png", "webp")
 
 
@@ -21,9 +22,10 @@ def get_image_paths(
 ) -> List[str]:
     # Get image paths
     path_to_find = os.path.join(path, '**') if recursive else os.path.join(path, '*')
-    image_paths = sorted(set(
-        [image for image in glob.glob(path_to_find, recursive=recursive)
-         if image.lower().endswith(SUPPORT_IMAGE_FORMATS)]), key=lambda filename: (os.path.splitext(filename)[0])
+    image_paths = sorted(
+        {image for image in glob.glob(path_to_find, recursive=recursive)
+         if image.lower().endswith(SUPPORT_IMAGE_FORMATS)},
+        key=lambda filename: os.path.splitext(filename)[0],
     ) if not os.path.isfile(path) else [str(path)] \
         if str(path).lower().endswith(SUPPORT_IMAGE_FORMATS) else None
 


### PR DESCRIPTION
## Summary
- extend the GUI advanced options with top‑k and top‑p sliders
- forward the new slider values to inference in single and batch modes
- normalize some import orders and remove extraneous f-strings via ruff

## Testing
- `ruff check wd_llm_caption/gui.py wd_llm_caption/caption.py wd_llm_caption/utils/image.py wd_llm_caption/utils/inference.py`
- `python -m py_compile wd_llm_caption/gui.py wd_llm_caption/caption.py wd_llm_caption/utils/image.py wd_llm_caption/utils/inference.py`


------
https://chatgpt.com/codex/tasks/task_e_6845a4e733788324b384d6b0bc731172